### PR TITLE
Don't append a 1 to company identification

### DIFF
--- a/lib/ach/records/batch_header.rb
+++ b/lib/ach/records/batch_header.rb
@@ -12,7 +12,7 @@ module ACH::Records
     field :company_discretionary_data, String,
         lambda { |f| left_justify(f, 20)}, ''
     field :company_identification, String,
-        lambda { |f| f.length == 10 ? f : "1#{f}" }, nil, /\A.{9,10}\z/
+        nil, nil, /\A.{9,10}\z/
     # TODO This should be used to determine whether other records are valid for
     # this code. Should there be a Class for each code?
     # The default of PPD is purely for my benefit (Jared Morgan)


### PR DESCRIPTION
If the company identification id is 9 digits long (like ours) then the gem prefixes this with a 1. Not sure why you would need to do this but our contact at titan informs us we only need 9 zeros.

![screen shot 2015-06-08 at 15 32 37](https://cloud.githubusercontent.com/assets/526994/8037090/b90fe3a2-0df3-11e5-97cc-083ce02cde00.png)
