### PR TITLE
fix: Replace deprecated last argument calls [FINE-1292]

### DIFF
--- a/lib/ach/field_identifiers.rb
+++ b/lib/ach/field_identifiers.rb
@@ -51,7 +51,7 @@ module ACH
           if RUBY_VERSION < '1.9'
             val = Iconv.conv('ASCII//IGNORE', 'UTF8', val)
           else
-            val = val.encode Encoding.find('ASCII'), ENCODING_OPTIONS
+            val = val.encode(Encoding.find('ASCII'), **ENCODING_OPTIONS)
           end
         end
 


### PR DESCRIPTION
Fixes the deprecation warning `/bundle-cache/ruby/2.7.0/bundler/gems/ach-0c5b550c8852/lib/ach/field_identifiers.rb:54: warning: Using the last argument as keyword parameters is deprecated`. 

Unit tests cover this code change, so we can safely assume that this change will, at the very least, work correctly in most use cases.

[JIRA Ticket](https://alphasights.atlassian.net/browse/FINE-1292)